### PR TITLE
feat: add proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A FastAPI-based server providing API endpoints for extracting and processing You
 - Generate timestamped captions
 - RESTful API with Swagger/OpenAPI documentation
 - Docker support for easy deployment
+- Optional HTTP/HTTPS proxy support for all YouTube requests
 
 ## Requirements
 
@@ -68,6 +69,13 @@ Once the server is running, you can access:
 - API documentation: http://localhost:8000/docs
 - Alternative API documentation: http://localhost:8000/redoc
 
+### Proxy Support
+
+If YouTube is blocked on your network or you require additional privacy, supply the
+optional `proxy` field in request bodies. The value should be a full HTTP or HTTPS
+proxy URL (e.g., `http://user:password@127.0.0.1:8080`). Environment proxy variables
+are ignored; only the proxy provided in the request is used.
+
 ### API Endpoints
 
 #### 1. Get Video Metadata
@@ -79,9 +87,11 @@ POST /youtube/video-data
 Request body:
 ```json
 {
-  "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+  "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+  "proxy": "http://127.0.0.1:8080"
 }
 ```
+The `proxy` field is optional and lets the server perform requests through the specified HTTP/HTTPS proxy.
 
 Response:
 ```json
@@ -109,7 +119,8 @@ Request body:
 ```json
 {
   "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-  "languages": ["en"]
+  "languages": ["en"],
+  "proxy": "http://127.0.0.1:8080"
 }
 ```
 
@@ -128,7 +139,8 @@ Request body:
 ```json
 {
   "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-  "languages": ["en"]
+  "languages": ["en"],
+  "proxy": "http://127.0.0.1:8080"
 }
 ```
 

--- a/app/models/youtube.py
+++ b/app/models/youtube.py
@@ -8,9 +8,11 @@ class YouTubeRequest(BaseModel):
     Attributes:
         url: YouTube video URL
         languages: Optional list of language codes for captions
+        proxy: Optional proxy URL used for outbound requests
     """
     url: str
     languages: Optional[List[str]] = None
+    proxy: Optional[str] = None
 
 class VideoData(BaseModel):
     """

--- a/app/routes/youtube.py
+++ b/app/routes/youtube.py
@@ -12,14 +12,14 @@ router = APIRouter(
 @router.post("/video-data")
 async def get_video_data(request: YouTubeRequest):
     """Endpoint to get video metadata"""
-    return YouTubeTools.get_video_data(request.url)
+    return YouTubeTools.get_video_data(request.url, request.proxy)
 
 @router.post("/video-captions")
 async def get_video_captions(request: YouTubeRequest):
     """Endpoint to get video captions"""
-    return YouTubeTools.get_video_captions(request.url, request.languages)
+    return YouTubeTools.get_video_captions(request.url, request.languages, request.proxy)
 
 @router.post("/video-timestamps")
 async def get_video_timestamps(request: YouTubeRequest):
     """Endpoint to get video timestamps"""
-    return YouTubeTools.get_video_timestamps(request.url, request.languages)
+    return YouTubeTools.get_video_timestamps(request.url, request.languages, request.proxy)

--- a/app/utils/youtube_tools.py
+++ b/app/utils/youtube_tools.py
@@ -1,10 +1,11 @@
 import json
-from urllib.parse import urlparse, parse_qs, urlencode
-from urllib.request import urlopen
 from typing import Optional, List
+from urllib.parse import urlparse, parse_qs, urlencode
 
+import requests
 from fastapi import HTTPException
 from youtube_transcript_api import YouTubeTranscriptApi
+from youtube_transcript_api.proxies import GenericProxyConfig
 
 class YouTubeTools:
     @staticmethod
@@ -26,8 +27,13 @@ class YouTubeTools:
         return None
 
     @staticmethod
-    def get_video_data(url: str) -> dict:
-        """Function to get video data from a YouTube URL."""
+    def get_video_data(url: str, proxy: Optional[str] = None) -> dict:
+        """Function to get video data from a YouTube URL.
+
+        Args:
+            url: Link to the YouTube video.
+            proxy: Optional HTTP/HTTPS proxy URL used for the request.
+        """
         if not url:
             raise HTTPException(status_code=400, detail="No URL provided")
 
@@ -41,31 +47,37 @@ class YouTubeTools:
         try:
             params = {"format": "json", "url": f"https://www.youtube.com/watch?v={video_id}"}
             oembed_url = "https://www.youtube.com/oembed"
-            query_string = urlencode(params)
-            full_url = oembed_url + "?" + query_string
-
-            with urlopen(full_url) as response:
-                response_text = response.read()
-                video_data = json.loads(response_text.decode())
-                clean_data = {
-                    "title": video_data.get("title"),
-                    "author_name": video_data.get("author_name"),
-                    "author_url": video_data.get("author_url"),
-                    "type": video_data.get("type"),
-                    "height": video_data.get("height"),
-                    "width": video_data.get("width"),
-                    "version": video_data.get("version"),
-                    "provider_name": video_data.get("provider_name"),
-                    "provider_url": video_data.get("provider_url"),
-                    "thumbnail_url": video_data.get("thumbnail_url"),
-                }
-                return clean_data
+            proxies = {"http": proxy, "https": proxy} if proxy else {}
+            session = requests.Session()
+            session.trust_env = False  # ignore HTTP(S)_PROXY environment variables
+            response = session.get(oembed_url, params=params, proxies=proxies)
+            response.raise_for_status()
+            video_data = response.json()
+            clean_data = {
+                "title": video_data.get("title"),
+                "author_name": video_data.get("author_name"),
+                "author_url": video_data.get("author_url"),
+                "type": video_data.get("type"),
+                "height": video_data.get("height"),
+                "width": video_data.get("width"),
+                "version": video_data.get("version"),
+                "provider_name": video_data.get("provider_name"),
+                "provider_url": video_data.get("provider_url"),
+                "thumbnail_url": video_data.get("thumbnail_url"),
+            }
+            return clean_data
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Error getting video data: {str(e)}")
 
     @staticmethod
-    def get_video_captions(url: str, languages: Optional[List[str]] = None) -> str:
-        """Get captions from a YouTube video."""
+    def get_video_captions(url: str, languages: Optional[List[str]] = None, proxy: Optional[str] = None) -> str:
+        """Get captions from a YouTube video.
+
+        Args:
+            url: Link to the YouTube video.
+            languages: Optional list of language codes to filter captions.
+            proxy: Optional HTTP/HTTPS proxy URL used for the request.
+        """
         if not url:
             raise HTTPException(status_code=400, detail="No URL provided")
 
@@ -77,21 +89,26 @@ class YouTubeTools:
             raise HTTPException(status_code=400, detail="Error getting video ID from URL")
 
         try:
-            captions = None
-            if languages:
-                captions = YouTubeTranscriptApi.get_transcript(video_id, languages=languages)
-            else:
-                captions = YouTubeTranscriptApi.get_transcript(video_id)
-            
+            proxy_config = GenericProxyConfig(http_url=proxy, https_url=proxy) if proxy else None
+            session = requests.Session()
+            session.trust_env = False  # ignore HTTP(S)_PROXY environment variables
+            api = YouTubeTranscriptApi(proxy_config=proxy_config, http_client=session)
+            captions = api.fetch(video_id, languages=languages or ["en"])
             if captions:
-                return " ".join(line["text"] for line in captions)
+                return " ".join(snippet.text for snippet in captions)
             return "No captions found for video"
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Error getting captions for video: {str(e)}")
 
     @staticmethod
-    def get_video_timestamps(url: str, languages: Optional[List[str]] = None) -> List[str]:
-        """Generate timestamps for a YouTube video based on captions."""
+    def get_video_timestamps(url: str, languages: Optional[List[str]] = None, proxy: Optional[str] = None) -> List[str]:
+        """Generate timestamps for a YouTube video based on captions.
+
+        Args:
+            url: Link to the YouTube video.
+            languages: Optional list of language codes to filter captions.
+            proxy: Optional HTTP/HTTPS proxy URL used for the request.
+        """
         if not url:
             raise HTTPException(status_code=400, detail="No URL provided")
 
@@ -103,12 +120,16 @@ class YouTubeTools:
             raise HTTPException(status_code=400, detail="Error getting video ID from URL")
 
         try:
-            captions = YouTubeTranscriptApi.get_transcript(video_id, languages=languages or ["en"])
+            proxy_config = GenericProxyConfig(http_url=proxy, https_url=proxy) if proxy else None
+            session = requests.Session()
+            session.trust_env = False  # ignore HTTP(S)_PROXY environment variables
+            api = YouTubeTranscriptApi(proxy_config=proxy_config, http_client=session)
+            captions = api.fetch(video_id, languages=languages or ["en"])
             timestamps = []
-            for line in captions:
-                start = int(line["start"])
+            for snippet in captions:
+                start = int(snippet.start)
                 minutes, seconds = divmod(start, 60)
-                timestamps.append(f"{minutes}:{seconds:02d} - {line['text']}")
+                timestamps.append(f"{minutes}:{seconds:02d} - {snippet.text}")
             return timestamps
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"Error generating timestamps: {str(e)}")


### PR DESCRIPTION
## Summary
- allow clients to specify an optional proxy for YouTube requests
- route proxy settings through API endpoints and utilities
- document proxy usage in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac286ea7508323b380723aa056ca76